### PR TITLE
feat: allow CORS by adding security config on application

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	runtimeOnly 'org.postgresql:postgresql'
 	providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/n7ws/back/api/UserController.java
+++ b/src/main/java/com/n7ws/back/api/UserController.java
@@ -4,11 +4,15 @@ import java.util.Collection;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.n7ws.back.entity.UserEntity;
 import com.n7ws.back.mapper.UserMapper;
 import com.n7ws.back.model.UserModel;
 import com.n7ws.back.repository.UserRepository;
@@ -23,6 +27,7 @@ import com.n7ws.back.repository.UserRepository;
  * @version 1.0
  */
 @RestController
+@CrossOrigin(origins = "http://localhost:3000")
 @RequestMapping("/users")
 public class UserController {
 
@@ -45,5 +50,11 @@ public class UserController {
 			.findFirst()
 			.map(user -> UserMapper.toModel(user))
 			.orElse(null);
+	}
+
+	@PostMapping
+	public UserEntity createUser(@RequestBody UserModel user) {
+		UserEntity userEntity = UserMapper.toEntity(user);
+		return repository.save(userEntity);
 	}
 }

--- a/src/main/java/com/n7ws/back/config/CustomCorsConfiguration.java
+++ b/src/main/java/com/n7ws/back/config/CustomCorsConfiguration.java
@@ -1,0 +1,20 @@
+package com.n7ws.back.config;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import jakarta.servlet.http.HttpServletRequest;
+
+@Component
+public class CustomCorsConfiguration implements CorsConfigurationSource {
+    @Override
+    public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of("http://localhost:5173", "http://127.0.0.1:5173"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE"));
+        config.setAllowedHeaders(List.of("*"));
+        return config;
+    }
+}

--- a/src/main/java/com/n7ws/back/config/SecurityConfig.java
+++ b/src/main/java/com/n7ws/back/config/SecurityConfig.java
@@ -1,0 +1,23 @@
+package com.n7ws.back.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+
+@Configuration
+public class SecurityConfig {
+
+    @Autowired CustomCorsConfiguration customCorsConfiguration;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(req -> req.anyRequest().permitAll())
+                .cors(c -> c.configurationSource(customCorsConfiguration));
+        return httpSecurity.build();
+    }
+}


### PR DESCRIPTION
Globalement :
- Ajout de la dépendance spring-boot-starter-security
- 2 fichiers de config, : un pour autoriser les requete vers le port 5173 et un autre pour overwrite la sécu spring boot qui bloque les requetes.

Basé sur : https://medium.com/@sallu-salman/cross-origin-resource-sharing-cors-in-spring-boot-applications-116163a88adc 